### PR TITLE
Exclude broader concepts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           AUTHORS_SUGGESTION_API_BASE_URL: http://localhost:9000
           ONTOTEXT_SUGGESTION_API_BASE_URL: http://localhost:9000
           CONCEPT_CONCORDANCES_API_BASE_URL: http://localhost:9000
+          PUBLIC_THINGS_API_BASE_URL: http://localhost:9000
       - image: peteclarkft/ersatz:stable
     steps:
       - checkout

--- a/helm/public-suggestions-api/app-configs/public-suggestions-api_delivery.yaml
+++ b/helm/public-suggestions-api/app-configs/public-suggestions-api_delivery.yaml
@@ -10,6 +10,8 @@ env:
   ONTOTEXT_SUGGESTION_ENDPOINT: "/content/suggest/ontotext"
   CONCEPT_CONCORDANCES_API_BASE_URL: "http://internal-concordances:8080"
   CONCEPT_CONCORDANCES_ENDPOINT: "/internalconcordances"
+  PUBLIC_THINGS_API_BASE_URL: "http://public-things-api:8080"
+  PUBLIC_THINGS_ENDPOINT: "/things"
   DEFAULT_SOURCE_PERSON: "tme"
   DEFAULT_SOURCE_ORGANISATIONS: "tme"
   DEFAULT_SOURCE_LOCATIONS: "tme"

--- a/helm/public-suggestions-api/templates/deployment.yaml
+++ b/helm/public-suggestions-api/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
           value: "{{ .Values.env.ONTOTEXT_SUGGESTION_API_BASE_URL }}"
         - name: ONTOTEXT_SUGGESTION_ENDPOINT
           value: "{{ .Values.env.ONTOTEXT_SUGGESTION_ENDPOINT }}"
+        - name: PUBLIC_THINGS_API_BASE_URL
+          value: "{{ .Values.env.PUBLIC_THINGS_API_BASE_URL }}"
+        - name: PUBLIC_THINGS_ENDPOINT
+          value: "{{ .Values.env.PUBLIC_THINGS_ENDPOINT }}"
         - name: DEFAULT_SOURCE_PERSON
           value: "{{ .Values.env.DEFAULT_SOURCE_PERSON }}"
         - name: DEFAULT_SOURCE_ORGANISATIONS

--- a/helm/public-suggestions-api/values.yaml
+++ b/helm/public-suggestions-api/values.yaml
@@ -21,6 +21,8 @@ env:
   AUTHORS_SUGGESTION_ENDPOINT: "" # This should be defined in the specific app-configs folder
   ONTOTEXT_SUGGESTION_API_BASE_URL: "" # This should be defined in the specific app-configs folder
   ONTOTEXT_SUGGESTION_ENDPOINT: "" # This should be defined in the specific app-configs folder
+  PUBLIC_THINGS_API_BASE_URL: "" # This should be defined in the specific app-configs folder
+  PUBLIC_THINGS_ENDPOINT: "" # This should be defined in the specific app-configs folder
   DEFAULT_SOURCE_PERSON: "" # This should be defined in the specific app-configs folder
   DEFAULT_SOURCE_ORGANISATIONS: "" # This should be defined in the specific app-configs folder
   DEFAULT_SOURCE_LOCATIONS: "" # This should be defined in the specific app-configs folder

--- a/main.go
+++ b/main.go
@@ -97,6 +97,19 @@ func main() {
 		EnvVar: "CONCEPT_CONCORDANCES_ENDPOINT",
 	})
 
+	publicThingsAPIBaseURL := app.String(cli.StringOpt{
+		Name:   "public-things-api-base-url",
+		Value:  "http://public-things-api:8080",
+		Desc:   "The base URL for public things api",
+		EnvVar: "PUBLIC_THINGS_API_BASE_URL",
+	})
+	publicThingsEndpoint := app.String(cli.StringOpt{
+		Name:   "public-things-endpoint",
+		Value:  "/things",
+		Desc:   "The endpoint for public things api",
+		EnvVar: "PUBLIC_THINGS_ENDPOINT",
+	})
+
 	defaultSourcePerson := app.String(cli.StringOpt{
 		Name:   "default-source-person",
 		Value:  service.TmeSource,
@@ -152,7 +165,8 @@ func main() {
 		ontotextSuggester := service.NewOntotextSuggester(*ontotextSuggestionApiBaseURL, *ontotextSuggestionEndpoint, c)
 
 		concordanceService := service.NewConcordance(*internalConcordancesApiBaseURL, *internalConcordancesEndpoint, c)
-		suggester := service.NewAggregateSuggester(concordanceService, defaultSources, falconSuggester, authorsSuggester, ontotextSuggester)
+		broaderService := service.NewBroaderExcludeService(*publicThingsAPIBaseURL, *publicThingsEndpoint, c)
+		suggester := service.NewAggregateSuggester(concordanceService, broaderService, defaultSources, falconSuggester, authorsSuggester, ontotextSuggester)
 		healthService := NewHealthService(*appSystemCode, *appName, appDescription, falconSuggester.Check(), authorsSuggester.Check(), ontotextSuggester.Check(), concordanceService.Check())
 
 		serveEndpoints(*port, web.NewRequestHandler(suggester), healthService)

--- a/main_test.go
+++ b/main_test.go
@@ -359,6 +359,10 @@ func TestRequestHandler_all(t *testing.T) {
 						}
 					}
 				}`))
+		case strings.Contains(r.RequestURI, "/things"):
+			w.Write([]byte(`{
+					"things": {}
+				}`))
 		}
 	}))
 
@@ -379,7 +383,8 @@ func TestRequestHandler_all(t *testing.T) {
 	authorsSuggester := service.NewAuthorsSuggester(mockServer.URL, "/authors", c)
 	ontotextSuggester := service.NewOntotextSuggester(mockServer.URL, "/ontotext", c)
 	concordance := service.NewConcordance(mockServer.URL, "/internalconcordances", c)
-	suggester := service.NewAggregateSuggester(concordance, defaultConceptsSources, falconSuggester, authorsSuggester, ontotextSuggester)
+	broaderExcluder := service.NewBroaderExcludeService(mockServer.URL, "/things", c)
+	suggester := service.NewAggregateSuggester(concordance, broaderExcluder, defaultConceptsSources, falconSuggester, authorsSuggester, ontotextSuggester)
 	healthService := NewHealthService("mock", "mock", "", falconSuggester.Check(), authorsSuggester.Check(), ontotextSuggester.Check())
 
 	go func() {

--- a/service/aggregator.go
+++ b/service/aggregator.go
@@ -71,7 +71,7 @@ func (suggester *AggregateSuggester) GetSuggestions(payload []byte, tid string, 
 
 	results, err := suggester.BroaderExclude.excludeBroaderConcepts(responseMap, tid, flags.Debug)
 	if err != nil {
-		log.WithError(err).Warn("Couldn't exclude broader concepts. Response could contains the broader concepts as well")
+		log.WithError(err).Warn("Couldn't exclude broader concepts. Response might contain broader concepts as well")
 	} else {
 		responseMap = results
 	}

--- a/service/aggregator.go
+++ b/service/aggregator.go
@@ -10,16 +10,18 @@ import (
 const idsParamName = "ids"
 
 type AggregateSuggester struct {
-	DefaultSource map[string]string
-	Concordance   *ConcordanceService
-	Suggesters    []Suggester
+	DefaultSource  map[string]string
+	Concordance    *ConcordanceService
+	BroaderExclude *BroaderExcludeService
+	Suggesters     []Suggester
 }
 
-func NewAggregateSuggester(concordance *ConcordanceService, defaultTypesSources map[string]string, suggesters ...Suggester) *AggregateSuggester {
+func NewAggregateSuggester(concordance *ConcordanceService, broaderExcludingService *BroaderExcludeService, defaultTypesSources map[string]string, suggesters ...Suggester) *AggregateSuggester {
 	return &AggregateSuggester{
-		Concordance:   concordance,
-		DefaultSource: defaultTypesSources,
-		Suggesters:    suggesters,
+		Concordance:    concordance,
+		BroaderExclude: broaderExcludingService,
+		DefaultSource:  defaultTypesSources,
+		Suggesters:     suggesters,
 	}
 }
 
@@ -65,6 +67,13 @@ func (suggester *AggregateSuggester) GetSuggestions(payload []byte, tid string, 
 		if len(responseMap[key]) > 0 {
 			responseMap[key] = suggesterDelegate.FilterSuggestions(responseMap[key], flags)
 		}
+	}
+
+	results, err := suggester.BroaderExclude.excludeBroaderConcepts(responseMap, tid, flags.Debug)
+	if err != nil {
+		log.WithError(err).Warn("Couldn't exclude broader concepts. Response could contains the broader concepts as well")
+	} else {
+		responseMap = results
 	}
 
 	// preserve results order

--- a/service/broader_exclude.go
+++ b/service/broader_exclude.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	fp "path/filepath"
+	"strings"
+
+	"github.com/Financial-Times/go-fthealth/v1_1"
+	"github.com/Financial-Times/go-logger"
+)
+
+type BroaderExcludeService struct {
+	systemID             string
+	name                 string
+	PublicThingsBaseURL  string
+	PublicThingsEndpoint string
+	Client               Client
+	failureImpact        string
+}
+
+func NewBroaderExcludeService(publicThingsAPIBaseURL, publicThingsEndpoint string, client Client) *BroaderExcludeService {
+	return &BroaderExcludeService{
+		PublicThingsBaseURL:  publicThingsAPIBaseURL,
+		PublicThingsEndpoint: publicThingsEndpoint,
+		Client:               client,
+		name:                 "public-things-api",
+		systemID:             "public-things-api",
+		failureImpact:        "Excluding broader concepts will not work",
+	}
+}
+
+type broaderResponse struct {
+	Things map[string]Thing `json:"things"`
+}
+
+type Thing struct {
+	ID              string           `json:"id"`
+	BroaderConcepts []BroaderConcept `json:"broaderConcepts"`
+}
+
+type BroaderConcept struct {
+	ID string `json:"id"`
+}
+
+func (b *BroaderExcludeService) Check() v1_1.Check {
+	return v1_1.Check{
+		ID:               b.systemID,
+		BusinessImpact:   b.failureImpact,
+		Name:             fmt.Sprintf("%v Healthcheck", b.name),
+		PanicGuide:       "https://biz-ops.in.ft.com/System/public-things-api",
+		Severity:         2,
+		TechnicalSummary: fmt.Sprintf("%v is not available", b.name),
+		Checker:          b.healthCheck,
+	}
+}
+
+func (b *BroaderExcludeService) healthCheck() (string, error) {
+	req, err := http.NewRequest("GET", b.PublicThingsBaseURL+"/__gtg", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("User-Agent", "UPP public-suggestions-api")
+
+	resp, err := b.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Health check returned a non-200 HTTP status: %v", resp.StatusCode)
+	}
+	return fmt.Sprintf("%v is healthy", b.name), nil
+}
+
+func (b *BroaderExcludeService) excludeBroaderConcepts(suggestions map[int][]Suggestion, tid string, debugFlag string) (map[int][]Suggestion, error) {
+	var ids []string
+	for _, sourceSuggestions := range suggestions {
+		for _, suggestion := range sourceSuggestions {
+			ids = append(ids, fp.Base(suggestion.ID))
+		}
+	}
+
+	if len(ids) == 0 {
+		return suggestions, nil
+	}
+
+	results := make(map[int][]Suggestion)
+	broader, err := b.getBroaderConcepts(ids, tid)
+	if err != nil {
+		return suggestions, err
+	}
+
+	broaderConceptsChecker := make(map[string]bool)
+	for _, thing := range broader.Things {
+		for _, broaderConcept := range thing.BroaderConcepts {
+			broaderConceptsChecker[fp.Base(broaderConcept.ID)] = true
+		}
+	}
+	if len(broaderConceptsChecker) == 0 {
+		return suggestions, nil
+	}
+
+	for mapIdx, sourceSuggestions := range suggestions {
+		filteredSourceSuggestions := []Suggestion{}
+		for _, suggestion := range sourceSuggestions {
+			if broaderConceptsChecker[fp.Base(suggestion.ID)] {
+				if debugFlag != "" {
+					logger.WithField("ExcludedID", suggestion.ID).
+						WithField("ExcludedPrefLabel", suggestion.PrefLabel).
+						Info("Broader Concept excluded")
+				}
+				continue
+			}
+			filteredSourceSuggestions = append(filteredSourceSuggestions, suggestion)
+		}
+		results[mapIdx] = filteredSourceSuggestions
+	}
+
+	return results, nil
+}
+
+func (b *BroaderExcludeService) getBroaderConcepts(ids []string, tid string) (*broaderResponse, error) {
+	var result broaderResponse
+	preparedURL := fmt.Sprintf("%s/%s", strings.TrimRight(b.PublicThingsBaseURL, "/"), strings.Trim(b.PublicThingsEndpoint, "/"))
+	req, err := http.NewRequest("GET", preparedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	queryParams := req.URL.Query()
+
+	for _, id := range ids {
+		queryParams.Add("uuid", id)
+	}
+
+	queryParams.Add("showRelationship", "broader")
+	queryParams.Add("showRelationship", "broaderTransitive")
+
+	req.URL.RawQuery = queryParams.Encode()
+
+	req.Header.Add("User-Agent", "UPP public-suggestions-api")
+	req.Header.Add("X-Request-Id", tid)
+
+	resp, err := b.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 status code returned: %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/service/broader_exclude_test.go
+++ b/service/broader_exclude_test.go
@@ -1,0 +1,559 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestBroaderExcludeService_CheckHealth(t *testing.T) {
+	expect := assert.New(t)
+	mockServer := new(mockSuggestionApiServer)
+	mockServer.On("GTG").Return(200).Once()
+	server := mockServer.startMockServer(t)
+
+	suggester := NewBroaderExcludeService(server.URL, "/__gtg", http.DefaultClient)
+	check := suggester.Check()
+	checkResult, err := check.Checker()
+
+	expect.Equal("public-things-api", check.ID)
+	expect.Equal("Excluding broader concepts will not work", check.BusinessImpact)
+	expect.Equal("public-things-api Healthcheck", check.Name)
+	expect.Equal("https://biz-ops.in.ft.com/System/public-things-api", check.PanicGuide)
+	expect.Equal("public-things-api is not available", check.TechnicalSummary)
+	expect.Equal(uint8(2), check.Severity)
+	expect.NoError(err)
+	expect.Equal("public-things-api is healthy", checkResult)
+	mock.AssertExpectationsForObjects(t, mockServer)
+}
+
+func TestBroaderExcludeService_CheckHealthUnhealthy(t *testing.T) {
+	expect := assert.New(t)
+	mockServer := new(mockSuggestionApiServer)
+	mockServer.On("GTG").Return(503)
+	server := mockServer.startMockServer(t)
+
+	suggester := NewBroaderExcludeService(server.URL, "/__gtg", http.DefaultClient)
+	checkResult, err := suggester.Check().Checker()
+
+	expect.Error(err)
+	expect.Empty(checkResult)
+	assert.Equal(t, "Health check returned a non-200 HTTP status: 503", err.Error())
+	mock.AssertExpectationsForObjects(t, mockServer)
+}
+
+func TestBroaderExcludeService_CheckHealthErrorOnNewRequest(t *testing.T) {
+	expect := assert.New(t)
+
+	suggester := NewBroaderExcludeService(":/", "/__gtg", http.DefaultClient)
+	checkResult, err := suggester.Check().Checker()
+
+	expect.Error(err)
+	assert.Equal(t, "parse ://__gtg: missing protocol scheme", err.Error())
+	expect.Empty(checkResult)
+}
+
+func TestBroaderExcludeService_CheckHealthErrorOnRequestDo(t *testing.T) {
+	expect := assert.New(t)
+	mockClient := new(mockHttpClient)
+	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{}, errors.New("Http Client err"))
+
+	suggester := NewBroaderExcludeService("http://test-url", "/__gtg", mockClient)
+	checkResult, err := suggester.Check().Checker()
+
+	expect.Error(err)
+	assert.Equal(t, "Http Client err", err.Error())
+	expect.Empty(checkResult)
+	mockClient.AssertExpectations(t)
+}
+
+func TestBroaderService_excludeBroaderConcepts(t *testing.T) {
+	ast := assert.New(t)
+
+	testCases := []struct {
+		testName    string
+		suggestions map[int][]Suggestion
+
+		expectedSuggestions   map[int][]Suggestion
+		expectedErrorContains string
+
+		publicThingsResponse    broaderResponse
+		publicThingsStatusCode  int
+		publicThingsError       error
+		publicThingsCallSkipped bool
+	}{
+		{
+			testName: "ok_NoExclude",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{
+					"6f14ea94-690f-3ed4-98c7-b926683c735a": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/993cce16-dcf8-11e8-950b-6c96cfdf3997",
+							},
+						},
+					},
+				},
+			},
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "ok_Exclude",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{
+					"6f14ea94-690f-3ed4-98c7-b926683c735a": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							},
+						},
+					},
+				},
+			},
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "ok_noSuggestionsReceived",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{},
+			},
+			suggestions:             map[int][]Suggestion{},
+			expectedSuggestions:     map[int][]Suggestion{},
+			publicThingsCallSkipped: true,
+		},
+		{
+			testName: "error_non200",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{},
+			},
+			publicThingsStatusCode: http.StatusBadGateway,
+			expectedErrorContains:  "non 200 status code returned: 502",
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "ok_ExcludedMultipleConcepts",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{
+					"a13db394-dd01-11e8-a00d-6c96cfdf3997": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/a1a2f869-dd01-11e8-abd7-6c96cfdf3997",
+							},
+						},
+					},
+					"a1a2f869-dd01-11e8-abd7-6c96cfdf3997": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/a1f96d3d-dd01-11e8-b32e-6c96cfdf3997",
+							},
+						},
+					},
+					"ca26a873-dd01-11e8-9a17-6c96cfdf3997": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/c9e114c1-dd01-11e8-8d2b-6c96cfdf3997",
+							},
+							{
+								ID: "http://www.ft.com/thing/c517ae15-dd01-11e8-aaba-6c96cfdf3997",
+							},
+						},
+					},
+					"c9e114c1-dd01-11e8-8d2b-6c96cfdf3997": Thing{
+						BroaderConcepts: []BroaderConcept{
+							{
+								ID: "http://www.ft.com/thing/c517ae15-dd01-11e8-aaba-6c96cfdf3997",
+							},
+						},
+					},
+				},
+			},
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a13db394-dd01-11e8-a00d-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a13db394-dd01-11e8-a00d-6c96cfdf3997",
+							PrefLabel:  "Bank of England",
+							Type:       "http://www.ft.com/ontology/organisation/Organisation",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a1a2f869-dd01-11e8-abd7-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a1a2f869-dd01-11e8-abd7-6c96cfdf3997",
+							PrefLabel:  "Global Banking",
+							Type:       "http://www.ft.com/ontology/organisation/Organisation",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a1f96d3d-dd01-11e8-b32e-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a1f96d3d-dd01-11e8-b32e-6c96cfdf3997",
+							PrefLabel:  "Economy",
+							Type:       "http://www.ft.com/ontology/organisation/Organisation",
+							IsFTAuthor: false,
+						},
+					},
+				},
+				2: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a2a0e506-dd01-11e8-b8b5-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a2a0e506-dd01-11e8-b8b5-6c96cfdf3997",
+							PrefLabel:  "Google Inc.",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/c517ae15-dd01-11e8-aaba-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/c517ae15-dd01-11e8-aaba-6c96cfdf3997",
+							PrefLabel:  "Private company",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/c9e114c1-dd01-11e8-8d2b-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/c9e114c1-dd01-11e8-8d2b-6c96cfdf3997",
+							PrefLabel:  "Company",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/ca26a873-dd01-11e8-9a17-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/ca26a873-dd01-11e8-9a17-6c96cfdf3997",
+							PrefLabel:  "Apple",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a13db394-dd01-11e8-a00d-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a13db394-dd01-11e8-a00d-6c96cfdf3997",
+							PrefLabel:  "Bank of England",
+							Type:       "http://www.ft.com/ontology/organisation/Organisation",
+							IsFTAuthor: false,
+						},
+					},
+				},
+				2: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/a2a0e506-dd01-11e8-b8b5-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/a2a0e506-dd01-11e8-b8b5-6c96cfdf3997",
+							PrefLabel:  "Google Inc.",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/ca26a873-dd01-11e8-9a17-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/ca26a873-dd01-11e8-9a17-6c96cfdf3997",
+							PrefLabel:  "Apple",
+							Type:       "http://www.ft.com/ontology/Topic",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "ok_noResultsFromPublicThings",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{},
+			},
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "ok_errorFromPublicThings",
+			publicThingsResponse: broaderResponse{
+				Things: map[string]Thing{},
+			},
+			publicThingsError:     fmt.Errorf("Error from publicThingsAPI"),
+			expectedErrorContains: "Error from publicThingsAPI",
+			suggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+			expectedSuggestions: map[int][]Suggestion{
+				1: []Suggestion{
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							APIURL:     "http://api.ft.com/people/6f14ea94-690f-3ed4-98c7-b926683c735a",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+					{
+						Predicate: "http://www.ft.com/ontology/annotation/mentions",
+						Concept: Concept{
+							ID:         "http://www.ft.com/thing/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							APIURL:     "http://api.ft.com/people/2d2657e2-dcff-11e8-a112-6c96cfdf3997",
+							PrefLabel:  "Donald Kaberuka",
+							Type:       "http://www.ft.com/ontology/person/Person",
+							IsFTAuthor: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		publicThingsRespBytes, err := json.Marshal(testCase.publicThingsResponse)
+		ast.NoErrorf(err, "%s -> unexpected json marshal error", testCase.testName)
+
+		publicThingsMock := new(mockHttpClient)
+		if testCase.publicThingsStatusCode == 0 {
+			testCase.publicThingsStatusCode = http.StatusOK
+		}
+		if !testCase.publicThingsCallSkipped {
+			publicThingsMock.On("Do", mock.AnythingOfType("*http.Request")).Return(
+				&http.Response{
+					Body:       ioutil.NopCloser(bytes.NewReader(publicThingsRespBytes)),
+					StatusCode: testCase.publicThingsStatusCode,
+				},
+				testCase.publicThingsError,
+			).Once()
+		}
+
+		excludeService := NewBroaderExcludeService("dummyURL", "things", publicThingsMock)
+
+		res, err := excludeService.excludeBroaderConcepts(testCase.suggestions, "test_tid", "")
+		if err != nil {
+			ast.NotEmptyf(testCase.expectedErrorContains, "%s -> empty expected error", testCase.testName)
+			ast.Containsf(err.Error(), testCase.expectedErrorContains, "%s -> not expected error returned", testCase.testName)
+		} else {
+			ast.NoErrorf(err, "%s -> unexpected error during excluding broader concepts", testCase.testName)
+		}
+
+		// this is in here because the broaderExcludeService should return the same results as the ones that it received if an error occurrs
+		ast.Lenf(res, len(testCase.expectedSuggestions), "%s -> unexpected results len", testCase.testName)
+		for expectedIdx, expectedSourceResults := range testCase.expectedSuggestions {
+			actualResults, ok := res[expectedIdx]
+			ast.Truef(ok, "%s -> no source index %d found in the actual results", testCase.testName, expectedIdx)
+			for _, expectedSuggestion := range expectedSourceResults {
+				found := false
+				for _, actualSuggestion := range actualResults {
+					if actualSuggestion.ID == expectedSuggestion.ID {
+						found = true
+						break
+					}
+				}
+				ast.Truef(found, "%s -> suggestion(ID: %s) not found in results", testCase.testName, expectedSuggestion.ID)
+			}
+		}
+		publicThingsMock.AssertExpectations(t)
+	}
+}


### PR DESCRIPTION
This is needed for excluding the broader concepts out of the returned results.
This is needed because through the `public-annotations-api` the broader and broaderTransitive concepts are returned anyway.
Also returning suggestions with something that is not really specific to the article, can create confussion when you want to find out what the article is about.

Specs: https://docs.google.com/document/d/1bJKrvSH-CWSgUiB-rX5B5vx5z0YDeCE5IhlEtrcr6i8/edit#heading=h.e5q1tl5dih1h
Jira Issue: https://jira.ft.com/browse/FDC-235