### PR TITLE
Move up the calls calls to internal concordances

### DIFF
--- a/service/aggregator.go
+++ b/service/aggregator.go
@@ -40,6 +40,7 @@ func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (Suggest
 
 	var aggregateResp = SuggestionsResponse{Suggestions: make([]Suggestion, 0)}
 	var responseMap = map[int][]Suggestion{}
+	suggestErrors := []error{}
 
 	var mutex = sync.Mutex{}
 	var wg = sync.WaitGroup{}
@@ -48,6 +49,7 @@ func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (Suggest
 		wg.Add(1)
 		logEntry := logEntry
 		go func(i int, delegate Suggester) {
+			logEntry = logEntry.WithField("suggestions_service", delegate.GetName())
 			resp, sErr := delegate.GetSuggestions(data, tid)
 			if sErr != nil {
 				errMsg := "error calling " + delegate.GetName()
@@ -58,8 +60,20 @@ func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (Suggest
 					errEntry.Error(errMsg)
 				}
 			}
+
+			result, sErr := s.getConcordedSuggestions(tid, resp.Suggestions)
+			if sErr != nil {
+				logEntry.WithError(sErr).Error("failed to get concordances for suggestions")
+			} else {
+				result = delegate.FilterSuggestions(result)
+			}
+
+			// store result even if its empty
 			mutex.Lock()
-			responseMap[i] = resp.Suggestions
+			responseMap[i] = result
+			if sErr != nil {
+				suggestErrors = append(suggestErrors, sErr)
+			}
 			mutex.Unlock()
 			wg.Done()
 		}(key, suggesterDelegate)
@@ -78,17 +92,9 @@ func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (Suggest
 
 	wg.Wait()
 
-	responseMap, err = s.filterByInternalConcordances(responseMap, tid)
-	if err != nil {
-		return aggregateResp, err
+	if len(suggestErrors) != 0 {
+		return aggregateResp, suggestErrors[0]
 	}
-
-	for key, suggesterDelegate := range s.Suggesters {
-		if len(responseMap[key]) > 0 {
-			responseMap[key] = suggesterDelegate.FilterSuggestions(responseMap[key])
-		}
-	}
-
 	results, err := s.BroaderProvider.excludeBroaderConceptsFromResponse(responseMap, tid)
 	if err != nil {
 		logEntry.WithError(err).Warn("Couldn't exclude broader concepts. Response might contain broader concepts as well")
@@ -107,50 +113,40 @@ func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (Suggest
 	return aggregateResp, nil
 }
 
-func (s *AggregateSuggester) filterByInternalConcordances(suggestions map[int][]Suggestion, tid string) (map[int][]Suggestion, error) {
+func (s *AggregateSuggester) getConcordedSuggestions(tid string, suggestions []Suggestion) ([]Suggestion, error) {
 	logEntry := s.Log.WithTransactionID(tid)
 
 	logEntry.Debug("Calling internal concordances")
 
-	var filtered = map[int][]Suggestion{}
-	var concorded ConcordanceResponse
-
-	var ids []string
-	for i := 0; i < len(suggestions); i++ {
-		for _, suggestion := range suggestions[i] {
-			ids = append(ids, fp.Base(suggestion.Concept.ID))
-		}
+	ids := []string{}
+	for _, suggestion := range suggestions {
+		ids = append(ids, fp.Base(suggestion.Concept.ID))
 	}
 
 	ids = dedup(ids)
-
 	if len(ids) == 0 {
 		logEntry.Info("No suggestions for calling internal concordances!")
-		return filtered, nil
+		return nil, nil
 	}
 
 	concorded, err := s.Concordance.getConcordances(ids, tid)
 	if err != nil {
-		return filtered, err
+		return nil, err
 	}
-
-	total := 0
-	for index, suggestions := range suggestions {
-		filtered[index] = []Suggestion{}
-		for _, suggestion := range suggestions {
-			id := fp.Base(suggestion.Concept.ID)
-			c, ok := concorded.Concepts[id]
-			if ok {
-				filtered[index] = append(filtered[index], Suggestion{
-					Predicate: suggestion.Predicate,
-					Concept:   c,
-				})
-			}
+	filtered := []Suggestion{}
+	for _, suggestion := range suggestions {
+		id := fp.Base(suggestion.Concept.ID)
+		c, ok := concorded.Concepts[id]
+		if !ok {
+			continue
 		}
-		total += len(filtered[index])
+		filtered = append(filtered, Suggestion{
+			Predicate: suggestion.Predicate,
+			Concept:   c,
+		})
 	}
 
-	logEntry.Debugf("Retained %v of %v concepts using concordances", total, len(ids))
+	logEntry.Debugf("Retained %d of %d concepts using concordances", len(filtered), len(ids))
 
 	return filtered, nil
 }

--- a/service/aggregator_test.go
+++ b/service/aggregator_test.go
@@ -500,7 +500,6 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	suggestionApi := new(mockSuggestionApi)
 	mockConcordance := new(ConcordanceService)
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, errors.New("Ontotext err"))
-	suggestionApi.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]Suggestion{}, nil)
 
 	log := logger.NewUPPLogger("test-service", "panic")
 	mockClientPublicThings := new(mockHttpClient)
@@ -567,7 +566,6 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	}
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(suggestionsResponse, nil).Once()
 	suggestionApi.On("FilterSuggestions", suggestionsResponse.Suggestions, mock.Anything).Return(suggestionsResponse.Suggestions).Once()
-	suggestionApi.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion"), mock.Anything).Return([]Suggestion{}).Once()
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{

--- a/service/aggregator_test.go
+++ b/service/aggregator_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -499,7 +498,7 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	expect := assert.New(t)
 	suggestionApi := new(mockSuggestionApi)
 	mockConcordance := new(ConcordanceService)
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, errors.New("Ontotext err"))
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"})
 
 	log := logger.NewUPPLogger("test-service", "panic")
 	mockClientPublicThings := new(mockHttpClient)
@@ -549,7 +548,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	}
 	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
 
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, errors.New("Ontotext err")).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"}).Once()
 
 	suggestionsResponse := SuggestionsResponse{Suggestions: []Suggestion{
 		{

--- a/service/aggregator_test.go
+++ b/service/aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"sort"
 	"strings"
 	"testing"
@@ -17,6 +18,48 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func newInternalConcordansesMock(t *testing.T, tid string, concepts map[string]Concept) Client {
+	headers := http.Header{}
+	headers.Add("User-Agent", "UPP public-suggestions-api")
+	headers.Add("X-Request-Id", tid)
+
+	return &http.Client{
+		Transport: &mockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, headers, req.Header)
+				params := req.URL.Query()
+				assert.Equal(t, "false", params.Get("include_deprecated"))
+
+				ids := params[idsParamName]
+				responses := &ConcordanceResponse{
+					Concepts: map[string]Concept{},
+				}
+				for _, id := range ids {
+					responses.Concepts[id] = concepts[id]
+				}
+				rec := httptest.NewRecorder()
+				err := json.NewEncoder(rec.Body).Encode(responses)
+				if err != nil {
+					return nil, err
+				}
+
+				return rec.Result(), nil
+			},
+		},
+	}
+}
+
+type mockTransport struct {
+	handler func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.handler != nil {
+		return m.handler(req)
+	}
+	panic("round trip handler not provided")
+}
 
 func TestAggregateSuggester_GetAuthorSuggestionsSuccessfully(t *testing.T) {
 	expect := assert.New(t)
@@ -65,51 +108,38 @@ func TestAggregateSuggester_GetAuthorSuggestionsSuccessfully(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
-	// mock internal concordances response
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: map[string]Concept{
-			"9a5e3b4a-55da-498c-816f-9c534e1392b5": {
-				ID:        "http://www.ft.com/thing/9a5e3b4a-55da-498c-816f-9c534e1392b5",
-				APIURL:    "http://api.ft.com/people/9a5e3b4a-55da-498c-816f-9c534e1392b5",
-				PrefLabel: "Lawrence Summers",
-				Type:      "http://www.ft.com/ontology/person/Person",
-			},
-			"9a5e3b4a-55da-498c-816f-9c534e139260": {
-				ID:         "http://www.ft.com/thing/9a5e3b4a-55da-498c-816f-9c534e139260",
-				APIURL:     "http://api.ft.com/people/9a5e3b4a-55da-498c-816f-9c534e139260",
-				PrefLabel:  "Lawrence Summers",
-				Type:       "http://www.ft.com/ontology/person/Person",
-				IsFTAuthor: true,
-			},
-		},
-	}
 	log := logger.NewUPPLogger("test-service", "panic")
-	mockClient := new(mockHttpClient)
 	mockClientError := new(mockHttpClient)
-	expectedBody, err := json.Marshal(&mockInternalConcResp)
-	require.NoError(t, err)
-	buffer := &ClosingBuffer{
-		Buffer: bytes.NewBuffer(expectedBody),
-	}
-	req, err := http.NewRequest("GET", "internalConcordancesHost/internalconcordances", nil)
-	expect.NoError(err)
 
-	queryParams := req.URL.Query()
-	queryParams.Add(idsParamName, "9a5e3b4a-55da-498c-816f-9c534e1392b5")
-	queryParams.Add(idsParamName, "9a5e3b4a-55da-498c-816f-9c534e139265")
-	queryParams.Add(idsParamName, "9a5e3b4a-55da-498c-816f-9c534e139260")
-	queryParams.Add("include_deprecated", "false")
-	req.URL.RawQuery = queryParams.Encode()
+	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
+		"9a5e3b4a-55da-498c-816f-9c534e139260": {
+			ID:         "http://www.ft.com/thing/9a5e3b4a-55da-498c-816f-9c534e139260",
+			APIURL:     "http://api.ft.com/people/9a5e3b4a-55da-498c-816f-9c534e139260",
+			PrefLabel:  "Lawrence Summers",
+			Type:       "http://www.ft.com/ontology/person/Person",
+			IsFTAuthor: true,
+		},
+		"9a5e3b4a-55da-498c-816f-9c534e1392b5": {
+			ID:        "http://www.ft.com/thing/9a5e3b4a-55da-498c-816f-9c534e1392b5",
+			APIURL:    "http://api.ft.com/people/9a5e3b4a-55da-498c-816f-9c534e1392b5",
+			PrefLabel: "Lawrence Summers",
+			Type:      "http://www.ft.com/ontology/person/Person",
+		},
+		"9a5e3b4a-55da-498c-816f-9c534e139265": {
+			ID:         "http://www.ft.com/thing/9a5e3b4a-55da-498c-816f-9c534e139260",
+			APIURL:     "http://api.ft.com/people/9a5e3b4a-55da-498c-816f-9c534e139260",
+			PrefLabel:  "Lawrence Summers",
+			Type:       "http://www.ft.com/ontology/person/Person",
+			IsFTAuthor: true,
+		},
+	})
 
-	req.Header.Add("User-Agent", "UPP public-suggestions-api")
-	req.Header.Add("X-Request-Id", "tid_test")
-	mockClient.On("Do", req).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
 	mockClientError.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: ioutil.NopCloser(strings.NewReader("")), StatusCode: http.StatusInternalServerError}, nil)
 
 	// create all the services
 	ontotextSuggester := NewOntotextSuggester("ontotextnUrl", "ontotextEndpoint", ontotextMock)
 	authorsSuggester := NewAuthorsSuggester("authorsUrl", "authorsEndpoint", authorsMock)
-	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", mockClient)
+	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", internalConcordanceClient)
 	broaderProvider := NewBroaderConceptsProvider("publicThingsUrl", "/things", mockClientError)
 
 	blacklisterMock := new(mockHttpClient)
@@ -237,7 +267,6 @@ func TestAggregateSuggester_InternalConcordancesUnavailable(t *testing.T) {
 	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
 
 	expect.Error(err)
-	expect.Equal(err.Error(), "error during calling internal concordances")
 	expect.Len(response.Suggestions, 0)
 
 	suggestionAPI.AssertExpectations(t)
@@ -273,16 +302,6 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil)
 	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil)
 
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: make(map[string]Concept),
-	}
-	mockInternalConcResp.Concepts["ontotext-suggestion-api"] = Concept{
-		IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
-	}
-	mockInternalConcResp.Concepts["authors-suggestion-api"] = Concept{
-		IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
-	}
-
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
 		Body:       ioutil.NopCloser(strings.NewReader("")),
@@ -313,7 +332,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusServiceUnavailable,
-	}, nil).Once()
+	}, nil).Twice()
 	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 503", err.Error())
@@ -323,7 +342,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusBadRequest,
-	}, nil).Once()
+	}, nil).Twice()
 	response, err = aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 400", err.Error())
@@ -337,8 +356,6 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 
 	suggestionApi := new(mockSuggestionApi)
 	log := logger.NewUPPLogger("test-service", "panic")
-	mockClient := new(mockHttpClient)
-	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", mockClient)
 
 	ontotextSuggestion := SuggestionsResponse{Suggestions: []Suggestion{
 		{
@@ -370,21 +387,14 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: make(map[string]Concept),
-	}
-	mockInternalConcResp.Concepts["ontotext-suggestion-api"] = Concept{
-		IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
-	}
-	mockInternalConcResp.Concepts["authors-suggestion-api"] = Concept{
-		IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
-	}
-	expectedBody, err := json.Marshal(&mockInternalConcResp)
-	require.NoError(t, err)
-	buffer := &ClosingBuffer{
-		Buffer: bytes.NewBuffer(expectedBody),
-	}
-	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
+	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
+		"authors-suggestion-api": {
+			IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
+		},
+		"ontotext-suggestion-api": {
+			IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
+		},
+	})
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
@@ -392,6 +402,7 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", internalConcordanceClient)
 	broaderProvider := NewBroaderConceptsProvider("publicThingsUrl", "/things", mockClientPublicThings)
 
 	blacklisterMock := new(mockHttpClient)
@@ -445,32 +456,23 @@ func TestAggregateSuggester_GetPersonSuggestionsSuccessfully(t *testing.T) {
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: make(map[string]Concept),
-	}
-	mockInternalConcResp.Concepts["ontotext-suggestion-api"] = Concept{
-		IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
-	}
-	mockInternalConcResp.Concepts["authors-suggestion-api"] = Concept{
-		IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
-	}
+	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
+		"authors-suggestion-api": {
+			IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
+		},
+		"ontotext-suggestion-api": {
+			IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
+		},
+	})
 
 	log := logger.NewUPPLogger("test-service", "panic")
-	mockClient := new(mockHttpClient)
-	expectedBody, err := json.Marshal(&mockInternalConcResp)
-	require.NoError(t, err)
-	buffer := &ClosingBuffer{
-		Buffer: bytes.NewBuffer(expectedBody),
-	}
-	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
-
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusOK,
 	}, nil)
 
-	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", mockClient)
+	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", internalConcordanceClient)
 	broaderProvider := NewBroaderConceptsProvider("publicThingsUrl", "/things", mockClientPublicThings)
 
 	blacklisterMock := new(mockHttpClient)
@@ -498,6 +500,7 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	suggestionApi := new(mockSuggestionApi)
 	mockConcordance := new(ConcordanceService)
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, errors.New("Ontotext err"))
+	suggestionApi.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]Suggestion{}, nil)
 
 	log := logger.NewUPPLogger("test-service", "panic")
 	mockClientPublicThings := new(mockHttpClient)
@@ -564,6 +567,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	}
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(suggestionsResponse, nil).Once()
 	suggestionApi.On("FilterSuggestions", suggestionsResponse.Suggestions, mock.Anything).Return(suggestionsResponse.Suggestions).Once()
+	suggestionApi.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion"), mock.Anything).Return([]Suggestion{}).Once()
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
@@ -597,8 +601,15 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklist(t *testing.T) {
 
 	suggestionApi := new(mockSuggestionApi)
 	log := logger.NewUPPLogger("test-service", "panic")
-	mockClient := new(mockHttpClient)
-	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", mockClient)
+	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
+		"authors-suggestion-api": {
+			IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
+		},
+		"ontotext-suggestion-api": {
+			IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
+		},
+	})
+	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", internalConcordanceClient)
 
 	ontotextSuggestion := SuggestionsResponse{Suggestions: []Suggestion{
 		{
@@ -629,22 +640,6 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklist(t *testing.T) {
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
-
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: make(map[string]Concept),
-	}
-	mockInternalConcResp.Concepts["ontotext-suggestion-api"] = Concept{
-		IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
-	}
-	mockInternalConcResp.Concepts["authors-suggestion-api"] = Concept{
-		IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
-	}
-	expectedBody, err := json.Marshal(&mockInternalConcResp)
-	require.NoError(t, err)
-	buffer := &ClosingBuffer{
-		Buffer: bytes.NewBuffer(expectedBody),
-	}
-	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
@@ -677,8 +672,15 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklistError(t *testing.T) {
 
 	suggestionApi := new(mockSuggestionApi)
 	log := logger.NewUPPLogger("test-service", "panic")
-	mockClient := new(mockHttpClient)
-	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", mockClient)
+	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
+		"authors-suggestion-api": {
+			IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
+		},
+		"ontotext-suggestion-api": {
+			IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
+		},
+	})
+	mockConcordance := NewConcordance("internalConcordancesHost", "/internalconcordances", internalConcordanceClient)
 
 	ontotextSuggestion := SuggestionsResponse{Suggestions: []Suggestion{
 		{
@@ -709,22 +711,6 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklistError(t *testing.T) {
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
 	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
-
-	mockInternalConcResp := ConcordanceResponse{
-		Concepts: make(map[string]Concept),
-	}
-	mockInternalConcResp.Concepts["ontotext-suggestion-api"] = Concept{
-		IsFTAuthor: false, ID: "ontotext-suggestion-api", APIURL: "apiurl1", PrefLabel: "prefLabel1", Type: ontologyPersonType,
-	}
-	mockInternalConcResp.Concepts["authors-suggestion-api"] = Concept{
-		IsFTAuthor: true, ID: "authors-suggestion-api", APIURL: "apiurl2", PrefLabel: "prefLabel2", Type: ontologyPersonType,
-	}
-	expectedBody, err := json.Marshal(&mockInternalConcResp)
-	require.NoError(t, err)
-	buffer := &ClosingBuffer{
-		Buffer: bytes.NewBuffer(expectedBody),
-	}
-	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{

--- a/service/suggester_test.go
+++ b/service/suggester_test.go
@@ -249,9 +249,9 @@ func TestOntotextSuggester_GetSuggestionsWithServiceUnavailable(t *testing.T) {
 
 	suggester := NewOntotextSuggester(server.URL, "/content/suggest", http.DefaultClient)
 	suggestionResp, err := suggester.GetSuggestions([]byte("{}"), "tid_test")
-
-	expect.Error(err)
-	expect.Equal("Ontotext Suggestion API returned HTTP 503", err.Error())
+	var sErr *SuggesterErr
+	expect.True(errors.As(err, &sErr))
+	expect.Equal("Ontotext Suggestion API returned HTTP 503", sErr.Error())
 	expect.Nil(suggestionResp.Suggestions)
 
 	mock.AssertExpectationsForObjects(t, mockServer)
@@ -278,8 +278,9 @@ func TestOntotextSuggester_GetSuggestionsErrorOnRequestDo(t *testing.T) {
 	suggestionResp, err := suggester.GetSuggestions([]byte("{}"), "tid_test")
 
 	expect.Nil(suggestionResp.Suggestions)
-	expect.Error(err)
-	expect.Equal("Http Client err", err.Error())
+	var sErr *SuggesterErr
+	expect.True(errors.As(err, &sErr))
+	expect.Equal("Http Client err", sErr.Error())
 	mockClient.AssertExpectations(t)
 }
 
@@ -296,8 +297,9 @@ func TestOntotextSuggester_GetSuggestionsErrorOnResponseBodyRead(t *testing.T) {
 	suggestionResp, err := suggester.GetSuggestions([]byte("{}"), "tid_test")
 
 	expect.Nil(suggestionResp.Suggestions)
-	expect.Error(err)
-	expect.Equal("Read error", err.Error())
+	var sErr *SuggesterErr
+	expect.True(errors.As(err, &sErr))
+	expect.Equal("Read error", sErr.Error())
 	mockClient.AssertExpectations(t)
 	mockBody.AssertExpectations(t)
 }
@@ -312,8 +314,9 @@ func TestOntotextSuggester_GetSuggestionsErrorOnEmptyBodyResponse(t *testing.T) 
 	suggester := NewOntotextSuggester(server.URL, "/content/suggest", http.DefaultClient)
 	suggestionResp, err := suggester.GetSuggestions([]byte("{}"), "tid_test")
 
-	expect.Error(err)
-	expect.Equal("unexpected end of JSON input", err.Error())
+	var sErr *SuggesterErr
+	expect.True(errors.As(err, &sErr))
+	expect.Equal("unexpected end of JSON input", sErr.Error())
 	expect.Nil(suggestionResp.Suggestions)
 
 	mock.AssertExpectationsForObjects(t, mockServer)
@@ -440,8 +443,9 @@ func TestOntotext_ErrorFromService(t *testing.T) {
 	suggester := NewOntotextSuggester("ontotextURL", "ontotextEndpoint", ontotextHTTPMock)
 	resp, err := suggester.GetSuggestions([]byte("{}"), "tid_test")
 
-	expect.Error(err)
-	expect.Equal("Error from ontotext-suggestion-api", err.Error())
+	var sErr *SuggesterErr
+	expect.True(errors.As(err, &sErr))
+	expect.Equal("Error from ontotext-suggestion-api", sErr.Error())
 
 	expect.NotNil(resp)
 	expect.Len(resp.Suggestions, 0)

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -266,7 +266,6 @@ func TestRequestHandler_HandleSuggestionErrorOnGetSuggestions(t *testing.T) {
 	mockConcordance := &service.ConcordanceService{ConcordanceBaseURL: "concordanceBaseURL", ConcordanceEndpoint: "concordanceEndpoint", Client: mockClient}
 
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{Suggestions: []service.Suggestion{}}, errors.New("timeout error"))
-	mockSuggester.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]service.Suggestion{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,
@@ -308,7 +307,6 @@ func TestRequestHandler_HandleSuggestionOkWhenNoContentSuggestions(t *testing.T)
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{
 		Suggestions: make([]service.Suggestion, 0),
 	}, service.NoContentError)
-	mockSuggester.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]service.Suggestion{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -266,6 +266,7 @@ func TestRequestHandler_HandleSuggestionErrorOnGetSuggestions(t *testing.T) {
 	mockConcordance := &service.ConcordanceService{ConcordanceBaseURL: "concordanceBaseURL", ConcordanceEndpoint: "concordanceEndpoint", Client: mockClient}
 
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{Suggestions: []service.Suggestion{}}, errors.New("timeout error"))
+	mockSuggester.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]service.Suggestion{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,
@@ -307,6 +308,7 @@ func TestRequestHandler_HandleSuggestionOkWhenNoContentSuggestions(t *testing.T)
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{
 		Suggestions: make([]service.Suggestion, 0),
 	}, service.NoContentError)
+	mockSuggester.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]service.Suggestion{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,
@@ -346,6 +348,7 @@ func TestRequestHandler_HandleSuggestionOkWhenEmptySuggestions(t *testing.T) {
 	mockConcordance := &service.ConcordanceService{ConcordanceBaseURL: "concordanceBaseURL", ConcordanceEndpoint: "concordanceEndpoint", Client: mockClient}
 
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{Suggestions: []service.Suggestion{}}, nil)
+	mockSuggester.On("FilterSuggestions", mock.AnythingOfType("[]service.Suggestion")).Return([]service.Suggestion{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -265,7 +265,7 @@ func TestRequestHandler_HandleSuggestionErrorOnGetSuggestions(t *testing.T) {
 	mockPublicThings := new(mockHttpClient)
 	mockConcordance := &service.ConcordanceService{ConcordanceBaseURL: "concordanceBaseURL", ConcordanceEndpoint: "concordanceEndpoint", Client: mockClient}
 
-	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{Suggestions: []service.Suggestion{}}, errors.New("timeout error"))
+	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{Suggestions: []service.Suggestion{}}, &service.SuggesterErr{})
 
 	broaderService := &service.BroaderConceptsProvider{
 		Client: mockPublicThings,
@@ -303,7 +303,6 @@ func TestRequestHandler_HandleSuggestionOkWhenNoContentSuggestions(t *testing.T)
 	mockPublicThings := new(mockHttpClient)
 	mockConcordance := &service.ConcordanceService{ConcordanceBaseURL: "concordanceBaseURL", ConcordanceEndpoint: "concordanceEndpoint", Client: mockClient}
 
-	service.NoContentError = errors.New("No content error")
 	mockSuggester.On("GetSuggestions", body, "tid_test").Return(service.SuggestionsResponse{
 		Suggestions: make([]service.Suggestion, 0),
 	}, service.NoContentError)


### PR DESCRIPTION
# Description

## What

Change the service to call `internal-concordances` multiple times for each suggestions provider, instead of single aggregated call for all suggestions.

## Why

Before this change the service gathered all the suggestions from `authors-suggestions-api` and `ontotext-suggestions-api`. Than it made a single request to `internal-concordances` in order to resolve prefUUIDs for the suggested concepts and get concept types and labels.
But by the nature of how it's setup, `internal-concordances` is able to return maximum 50 concepts. This means that in some cases the service is dropping suggestions. To mitigate this problem we move the call to `internal-concordances` to be per suggestions provider.

More info on the problem can be found here: https://financialtimes.atlassian.net/browse/UPPSF-2197

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
