### PR TITLE
Remove FastFT reference from test

### DIFF
--- a/service/transformer_test.go
+++ b/service/transformer_test.go
@@ -50,11 +50,11 @@ func TestTextTransform(t *testing.T) {
 }
 
 func TestBlogTransform(t *testing.T) {
-	inputText := `<body><p><a href="http://www.ft.com/fastft/files/2017/02/Fake_blog_post_title-line_chart-ft-web-themelarge-600x397.1234567890.png"><img alt="" height="398" src="http://www.ft.com/fastft/files/2017/02/Fake_blog_post_title-line_chart-ft-web-themelarge-600x397.1234567890.png" width="600"/></a></p>
+	inputText := `<body><p><a href="http://www.ft.com/fake-blog/files/2017/02/Fake_blog_post_title-line_chart-ft-web-themelarge-600x397.1234567890.png"><img alt="" height="398" src="http://www.ft.com/fake-blog/files/2017/02/Fake_blog_post_title-line_chart-ft-web-themelarge-600x397.1234567890.png" width="600"/></a></p>
 <p>Aliquam sagittis ipsum non tortor placerat scelerisque.</p>
 <p>Maecenas lobortis purus ut cursus tempor. Vestibulum lacus neque, auctor et euismod in, ultricies dictum sem. Fusce finibus erat quis ipsum pharetra, quis vehicula urna varius. Donec consequat pellentesque erat nec porta.</p>
 <p>Praesent vel leo feugiat, rhoncus quam quis, ullamcorper augue. Pellentesque quis nisi nec sapien accumsan efficitur. Quisque commodo mollis metus.</p>
-<p><a href="http://www.ft.com/fastft/files/2017/02/fake-image.png"><img alt="" height="382" src="http://www.ft.com/fastft/files/2017/02/fake-image.png" width="733"/></a></p>
+<p><a href="http://www.ft.com/fake-blog/files/2017/02/fake-image.png"><img alt="" height="382" src="http://www.ft.com/fake-blog/files/2017/02/fake-image.png" width="733"/></a></p>
 <p>Aliquam eros tellus, pharetra non orci eu, dictum semper enim. Donec vel dapibus mi, vel fermentum sapien.</p>
 <p>Ut nec nibh ex. Proin dignissim ipsum at lacus condimentum efficitur. Donec at felis felis. Etiam sagittis condimentum maximus.</p>
 <p><em>Donec id faucibus erat </em></p>


### PR DESCRIPTION
# Description

## What

Remove FastFT reference from test because it's deprecated now.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2510).

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
