### PR TITLE
Forward 'X-Origin' request header

### DIFF
--- a/reqorigin/reqorigin.go
+++ b/reqorigin/reqorigin.go
@@ -2,11 +2,22 @@
 // http request.
 package reqorigin
 
-import "net/http"
+import (
+	"net/http"
+)
 
 const OriginKey = "X-Origin"
 
 // FromRequest extracts the value of the 'X-Origin' header.
 func FromRequest(req *http.Request) string {
 	return req.Header.Get(OriginKey)
+}
+
+// SetHeader sets X-Origin: origin to the request headers.
+//
+// If origin is empty string, it does nothing.
+func SetHeader(req *http.Request, origin string) {
+	if origin != "" {
+		req.Header.Add(OriginKey, origin)
+	}
 }

--- a/reqorigin/reqorigin.go
+++ b/reqorigin/reqorigin.go
@@ -1,0 +1,12 @@
+// Package reqorigin provides functions for extracting 'X-Origin' header from
+// http request.
+package reqorigin
+
+import "net/http"
+
+const OriginKey = "X-Origin"
+
+// FromRequest extracts the value of the 'X-Origin' header.
+func FromRequest(req *http.Request) string {
+	return req.Header.Get(OriginKey)
+}

--- a/service/aggregator.go
+++ b/service/aggregator.go
@@ -28,7 +28,7 @@ func NewAggregateSuggester(log *logger.UPPLogger, concordance *ConcordanceServic
 	}
 }
 
-func (s *AggregateSuggester) GetSuggestions(payload []byte, tid string) (SuggestionsResponse, error) {
+func (s *AggregateSuggester) GetSuggestions(payload []byte, tid, origin string) (SuggestionsResponse, error) {
 	logEntry := s.Log.WithTransactionID(tid)
 
 	var aggregateResp = SuggestionsResponse{Suggestions: make([]Suggestion, 0)}

--- a/service/aggregator_test.go
+++ b/service/aggregator_test.go
@@ -151,7 +151,7 @@ func TestAggregateSuggester_GetAuthorSuggestionsSuccessfully(t *testing.T) {
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, ontotextSuggester, authorsSuggester)
 
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 2)
@@ -263,7 +263,7 @@ func TestAggregateSuggester_InternalConcordancesUnavailable(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionAPI, suggestionAPI)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.Error(err)
 	expect.Len(response.Suggestions, 0)
@@ -332,7 +332,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusServiceUnavailable,
 	}, nil).Twice()
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 503", err.Error())
 	expect.Len(response.Suggestions, 0)
@@ -342,7 +342,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusBadRequest,
 	}, nil).Twice()
-	response, err = aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err = aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 400", err.Error())
 	expect.Len(response.Suggestions, 0)
@@ -413,7 +413,7 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.Len(response.Suggestions, 2)
 
@@ -483,7 +483,7 @@ func TestAggregateSuggester_GetPersonSuggestionsSuccessfully(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 2)
@@ -518,7 +518,7 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 0)
@@ -583,7 +583,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 1)
@@ -655,7 +655,7 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklist(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.Len(response.Suggestions, 1)
 
@@ -726,7 +726,7 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklistError(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
 
 	expect.Len(response.Suggestions, 2)
 

--- a/service/aggregator_test.go
+++ b/service/aggregator_test.go
@@ -151,7 +151,7 @@ func TestAggregateSuggester_GetAuthorSuggestionsSuccessfully(t *testing.T) {
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, ontotextSuggester, authorsSuggester)
 
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 2)
@@ -187,7 +187,7 @@ func TestAggregateSuggester_GetSuggestionsSuccessfullyResponseFiltered(t *testin
 	defer server.Close()
 
 	suggester := NewOntotextSuggester(server.URL, "/content/suggest", http.DefaultClient)
-	suggestionResp, err := suggester.GetSuggestions(body, "tid_test")
+	suggestionResp, err := suggester.GetSuggestions(body, "tid_test", "tests_origin")
 	suggestionResp.Suggestions = suggester.FilterSuggestions(suggestionResp.Suggestions)
 
 	actualSuggestions := suggestionResp.Suggestions
@@ -228,8 +228,8 @@ func TestAggregateSuggester_InternalConcordancesUnavailable(t *testing.T) {
 			},
 		},
 	}}
-	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil).Once()
-	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
+	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil).Once()
+	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil).Once()
 
 	mockInternalConcResp := ConcordanceResponse{
 		Concepts: make(map[string]Concept),
@@ -263,7 +263,7 @@ func TestAggregateSuggester_InternalConcordancesUnavailable(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionAPI, suggestionAPI)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.Error(err)
 	expect.Len(response.Suggestions, 0)
@@ -298,8 +298,8 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 			},
 		},
 	}}
-	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil)
-	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil)
+	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil)
+	suggestionAPI.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil)
 
 	mockClientPublicThings := new(mockHttpClient)
 	mockClientPublicThings.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
@@ -332,7 +332,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusServiceUnavailable,
 	}, nil).Twice()
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 503", err.Error())
 	expect.Len(response.Suggestions, 0)
@@ -342,7 +342,7 @@ func TestAggregateSuggester_InternalConcordancesUnexpectedStatus(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 		StatusCode: http.StatusBadRequest,
 	}, nil).Twice()
-	response, err = aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err = aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 	expect.Error(err)
 	expect.Equal("non 200 status code returned: 400", err.Error())
 	expect.Len(response.Suggestions, 0)
@@ -381,9 +381,9 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 	},
 	}
 
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
 	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
@@ -413,7 +413,7 @@ func TestAggregateSuggester_GetSuggestionsSuccessfully(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.Len(response.Suggestions, 2)
 
@@ -450,9 +450,9 @@ func TestAggregateSuggester_GetPersonSuggestionsSuccessfully(t *testing.T) {
 			},
 		},
 	}}
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
 	internalConcordanceClient := newInternalConcordansesMock(t, "tid_test", map[string]Concept{
@@ -483,7 +483,7 @@ func TestAggregateSuggester_GetPersonSuggestionsSuccessfully(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 2)
@@ -498,7 +498,7 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	expect := assert.New(t)
 	suggestionApi := new(mockSuggestionApi)
 	mockConcordance := new(ConcordanceService)
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"})
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"})
 
 	log := logger.NewUPPLogger("test-service", "panic")
 	mockClientPublicThings := new(mockHttpClient)
@@ -518,7 +518,7 @@ func TestAggregateSuggester_GetEmptySuggestionsArrayIfNoAggregatedSuggestionAvai
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 0)
@@ -548,7 +548,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	}
 	mockClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{Body: buffer, StatusCode: http.StatusOK}, nil)
 
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"}).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(SuggestionsResponse{}, &SuggesterErr{msg: "Ontotext err"}).Once()
 
 	suggestionsResponse := SuggestionsResponse{Suggestions: []Suggestion{
 		{
@@ -563,7 +563,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 		},
 	},
 	}
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(suggestionsResponse, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(suggestionsResponse, nil).Once()
 	suggestionApi.On("FilterSuggestions", suggestionsResponse.Suggestions, mock.Anything).Return(suggestionsResponse.Suggestions).Once()
 
 	mockClientPublicThings := new(mockHttpClient)
@@ -583,7 +583,7 @@ func TestAggregateSuggester_GetSuggestionsNoErrorForOntotextSuggestionApi(t *tes
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, err := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.NoError(err)
 	expect.Len(response.Suggestions, 1)
@@ -633,9 +633,9 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklist(t *testing.T) {
 	},
 	}
 
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
 	mockClientPublicThings := new(mockHttpClient)
@@ -655,7 +655,7 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklist(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.Len(response.Suggestions, 1)
 
@@ -704,9 +704,9 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklistError(t *testing.T) {
 	},
 	}
 
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(ontotextSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(ontotextSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", ontotextSuggestion.Suggestions, mock.Anything).Return(ontotextSuggestion.Suggestions).Once()
-	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test").Return(authorsSuggestion, nil).Once()
+	suggestionApi.On("GetSuggestions", mock.AnythingOfType("[]uint8"), "tid_test", "tests_origin").Return(authorsSuggestion, nil).Once()
 	suggestionApi.On("FilterSuggestions", authorsSuggestion.Suggestions, mock.Anything).Return(authorsSuggestion.Suggestions).Once()
 
 	mockClientPublicThings := new(mockHttpClient)
@@ -726,7 +726,7 @@ func TestAggregateSuggester_GetSuggestionsWithBlacklistError(t *testing.T) {
 	blacklister := NewConceptBlacklister("blacklisterUrl", "blacklisterEndpoint", blacklisterMock)
 
 	aggregateSuggester := NewAggregateSuggester(log, mockConcordance, broaderProvider, blacklister, suggestionApi, suggestionApi)
-	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "")
+	response, _ := aggregateSuggester.GetSuggestions([]byte{}, "tid_test", "tests_origin")
 
 	expect.Len(response.Suggestions, 2)
 

--- a/service/suggester.go
+++ b/service/suggester.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	health "github.com/Financial-Times/go-fthealth/v1_1"
+	"github.com/Financial-Times/public-suggestions-api/reqorigin"
 )
 
 const (
@@ -82,7 +83,7 @@ type Client interface {
 }
 
 type Suggester interface {
-	GetSuggestions(payload []byte, tid string) (SuggestionsResponse, error)
+	GetSuggestions(payload []byte, tid, origin string) (SuggestionsResponse, error)
 	FilterSuggestions(suggestions []Suggestion) []Suggestion
 	GetName() string
 }
@@ -146,7 +147,7 @@ func NewOntotextSuggester(ontotextSuggestionApiBaseURL, ontotextSuggestionEndpoi
 	}}
 }
 
-func (suggester *SuggestionApi) GetSuggestions(payload []byte, tid string) (SuggestionsResponse, error) {
+func (suggester *SuggestionApi) GetSuggestions(payload []byte, tid, origin string) (SuggestionsResponse, error) {
 
 	req, err := http.NewRequest("POST", suggester.apiBaseURL+suggester.suggestionEndpoint, bytes.NewReader(payload))
 	if err != nil {
@@ -157,6 +158,7 @@ func (suggester *SuggestionApi) GetSuggestions(payload []byte, tid string) (Sugg
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Request-Id", tid)
+	reqorigin.SetHeader(req, origin)
 
 	resp, err := suggester.client.Do(req)
 	if err != nil {

--- a/service/suggester.go
+++ b/service/suggester.go
@@ -148,7 +148,6 @@ func NewOntotextSuggester(ontotextSuggestionApiBaseURL, ontotextSuggestionEndpoi
 }
 
 func (suggester *SuggestionApi) GetSuggestions(payload []byte, tid, origin string) (SuggestionsResponse, error) {
-
 	req, err := http.NewRequest("POST", suggester.apiBaseURL+suggester.suggestionEndpoint, bytes.NewReader(payload))
 	if err != nil {
 		return SuggestionsResponse{}, &SuggesterErr{err: err}

--- a/web/handler.go
+++ b/web/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/Financial-Times/go-logger/v2"
+	"github.com/Financial-Times/public-suggestions-api/reqorigin"
 	"github.com/Financial-Times/public-suggestions-api/service"
 	tidutils "github.com/Financial-Times/transactionid-utils-go"
 )
@@ -44,7 +45,7 @@ func (h *RequestHandler) HandleSuggestion(resp http.ResponseWriter, req *http.Re
 		return
 	}
 
-	suggestions, err := h.suggester.GetSuggestions(body, tid)
+	suggestions, err := h.suggester.GetSuggestions(body, tid, reqorigin.FromRequest(req))
 	if err != nil {
 		errMsg := "aggregating suggestions failed!"
 		logEntry.WithError(err).Error(errMsg)


### PR DESCRIPTION
# Description

Forward 'X-Origin' request header from incoming requests to outgoing requests to `ontotext-suggestions-api` and `authors-suggestion-api`

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-3062)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
